### PR TITLE
replace innerHTML with createElement & fix sorting

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,8 +16,7 @@ async function loadRepos() {
   repos
     .filter(repo => repo.name.includes("You"))
     .sort((a, b) => b.stargazers_count - a.stargazers_count)
-    .map(repo => {
-      
+    .forEach(repo => {
       const a = x("a");
       a.className = "card";
       a.href = repo.html_url;

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
-let element = document.querySelector.bind(document);
+const $ = document.querySelector.bind(document);
+const x = document.createElement.bind(document);
 
 const reposUrl = "https://api.github.com/orgs/you-apps/repos";
 const membersUrl = "https://api.github.com/orgs/you-apps/members";
@@ -12,38 +13,51 @@ async function fetchJson(url) {
 
 async function loadRepos() {
   const repos = await fetchJson(reposUrl);
-  repos.sort((a, b) => a.stargazers_count < b.stargazers_count);
+  repos
+    .filter(repo => repo.name.includes("You"))
+    .sort((a, b) => b.stargazers_count - a.stargazers_count)
+    .map(repo => {
+      
+      const a = x("a");
+      a.className = "card";
+      a.href = repo.html_url;
 
-  for (const repo of repos) {
-    if (!repo.name.includes("You")) continue;
+      const img = x("img");
+      img.src = `https://raw.githubusercontent.com/you-apps/${repo.name}/main/fastlane/metadata/android/en-US/images/icon.png`;
 
-    const apps = `
-      <a class="card" href="${repo.html_url}">
-        <img src="https://raw.githubusercontent.com/you-apps/${repo.name}/main/fastlane/metadata/android/en-US/images/icon.png" alt="${repo.name} icon">
-        <div>
-          <h3>${repo.name}</h3>
-          <p>${repo.description}</p>
-        </div>
-        <span class="stars"><img src="assets/star.svg" alt="Star icon">${repo.stargazers_count}</span>
-      </a>
-    `;
+      const div = x("div");
+      const h3 = x("h3");
+      h3.textContent = repo.name;
+      const p = x("p");
+      p.textContent = repo.description;
+      div.append(h3, p);
 
-    element("#app-list").innerHTML += apps;
-  }
+      const span = x("span");
+      span.className = "stars";
+      const starIcon = x("img");
+      starIcon.src = "assets/star.svg";
+      span.append(starIcon, repo.stargazers_count);
+
+      a.append(img, div, span);
+      $("#apps > div").appendChild(a);
+    });
 }
 
 async function loadMembers() {
   const members = await fetchJson(membersUrl);
-
   for (const member of members) {
-    const team = `
-      <a class="card" href="${member.html_url}">
-        <img src="${member.avatar_url}" alt="${member.login} avatar">
-        <h3>${member.login}</h3>
-      </a>
-    `;
-
-    element("#member-list").innerHTML += team;
+    const a = x("a");
+    a.className = "card";
+    a.href = member.html_url;
+    
+    const img = x("img");
+    img.src = member.avatar_url;
+    
+    const h3 = x("h3");
+    h3.textContent = member.login;
+    
+    a.append(img, h3);
+    $("#team > div").appendChild(a);
   }
 }
 


### PR DESCRIPTION
This pull request replaces the use of innerHTML with createElement to create and insert HTML elements into the DOM. This is a more secure and efficient way to manipulate the DOM, and it also avoids some of the potential problems with innerHTML, such as XSS attacks.

In addition to replacing innerHTML, this pull request also updates the sorting algorithm used to sort the elements. The previous algorithm used the `a > b` operator, which is a bitwise operator. This operator can be slow and can also lead to unexpected results in some cases.

The new sorting algorithm uses the `b - a` operator, which is a mathematical operator. This operator is faster and more reliable than the `a > b` operator.

I have tested this pull request and it works as expected. Please let me know if you have any questions or concerns.